### PR TITLE
avoid `if(class() ==)`

### DIFF
--- a/R/clValid-functions.R
+++ b/R/clValid-functions.R
@@ -158,8 +158,8 @@ stability <- function(mat, Dist=NULL, del, cluster, clusterDel, method="euclidea
   dij <- matrix(rep(NA,nc1*nc2),nc1,nc2)
 
   if (is.null(Dist)) matDist <- as.matrix(dist(mat, method=method))
-  if (class(Dist)=="dist") matDist <- as.matrix(Dist)
-  if (class(Dist)=="matrix") matDist <- Dist
+  if (inherits(Dist, "dist")) matDist <- as.matrix(Dist)
+  if (is.matrix(Dist)) matDist <- Dist
 
   ## measure ADM
   ## calculate a ncxnc matrix of distance-average in the two collection of nc clusters
@@ -225,7 +225,7 @@ stability <- function(mat, Dist=NULL, del, cluster, clusterDel, method="euclidea
 mysilhouette <- function(distance=NULL, clusters, Data=NULL, method="euclidean"){
 
   if (is.null(distance)) distance <- as.matrix(dist(Data, method=method))
-  if (class(distance)=="dist") distance <- as.matrix(distance)
+  if (inherits(distance, "dist")) distance <- as.matrix(distance)
   dista <- apply(distance,2,function(x) tapply(x, clusters, function(x) na.rm=TRUE))
   nc <- ncol(dista); nr <- nrow(dista);
   a <- dista[matrix(c(clusters,1:nc),ncol=2,nrow=nc)]
@@ -246,7 +246,9 @@ connectivity <- function(distance=NULL, clusters, Data=NULL, neighbSize=10, meth
 
   if (is.null(distance) & is.null(Data)) stop("One of 'distance' or 'Data' is required")
   if (is.null(distance)) distance <- as.matrix(dist(Data, method=method))
-  if (class(distance)=="dist") distance <- as.matrix(distance)
+  if (inherits(distance, "dist")){
+    distance <- as.matrix(distance)
+  }
   nearest <- apply(distance,2,function(x) sort(x,ind=TRUE)$ix[2:(neighbSize+1)])
   nr <- nrow(nearest);nc <- ncol(nearest)
   same <- matrix(clusters,nrow=nr,ncol=nc,byrow=TRUE)!=matrix(clusters[nearest],nrow=nr,ncol=nc)
@@ -265,7 +267,7 @@ dunn <- function(distance=NULL, clusters, Data=NULL, method="euclidean"){
 
   if (is.null(distance) & is.null(Data)) stop("One of 'distance' or 'Data' is required")
   if (is.null(distance)) distance <- as.matrix(dist(Data, method=method))
-  if (class(distance)=="dist") distance <- as.matrix(distance)
+  if (inherits(distance, "dist")) distance <- as.matrix(distance)
   nc <- max(clusters)
   interClust <- matrix(NA, nc, nc)
   intraClust <- rep(NA, nc)
@@ -375,12 +377,12 @@ BHI <- function(statClust,annotation="",names=NULL,category="all",dropEvidence=N
     cat(paste("package",annotation,"not found, attempting download from Bioconductor\n",
               sep=" "))
     source("http://bioconductor.org/biocLite.R")
-    res <- try(biocLite(annotation))
-    if(class(res)=="try-error") {
-      stop(paste("attempted download of package", annotation, "failed, exiting"))
-    } else {
+    res <- tryCatch({
+      biocLite(annotation)
       requireNamespace(annotation)
-    }
+    }, error = function(e) {
+      stop(paste("attempted download of package", annotation, "failed, exiting"))
+    })
   }
   ##           if(!require(annotation,character.only=TRUE)) {
   ##             stop(paste("package",annotation,"not found",sep=" "))


### PR DESCRIPTION
The construct: 

```r
if (class(distance) == "dist") {
   ...
}
```

will generate warnings in recent versions of R when `distance` has more than one class. This was identified by CRAN as part of releasing dplyr 1.0.3 https://github.com/tidyverse/dplyr/issues/5599 as this was generating a bunch of warnings when testing other packages (e.g. `diceR`).  